### PR TITLE
Add openSUSE support for building docker images

### DIFF
--- a/image.spec.in
+++ b/image.spec.in
@@ -2,7 +2,7 @@
 
 Url:            http://www.suse.com/
 Name:           __NAME__
-Summary:        SUSE Linux Enterprise Server __SLE_VERSION__ image for Docker
+Summary:        __SUSE_PRODUCT_NAME__ __SUSE_VERSION__ image for Docker
 Version:        __VERSION__
 Release:        __RELEASE__
 Group:          System/Management
@@ -12,7 +12,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Recommends:     sle2docker
 
 %description
-This package contains the official SUSE Linux Enterprise Server __SLE_VERSION__
+This package contains the official __SUSE_PRODUCT_NAME__ __SUSE_VERSION__
 image for Docker.
 
 %prep

--- a/kiwi_post_run
+++ b/kiwi_post_run
@@ -30,10 +30,12 @@ echo "Using $SPEC_IN as spec file template"
 
 EXT=".tar.xz"
 ARCH=$( rpm --eval '%{_arch}')
-PREFIX="sles*-docker.${ARCH}-"
+PREFIX="@(sles|openSUSE)*-docker.${ARCH}-"
 SUFFIX="-Build*${EXT}"
 
 shopt -s nullglob
+shopt -s extglob
+
 IMAGE=$(echo ${PREFIX}*${SUFFIX})
 PACKAGES=$(echo ${PREFIX}*.packages)
 
@@ -45,10 +47,17 @@ fi
 
 echo "Attempting to wrap $IMAGE in a containment rpm ..."
 
-SLE_VERSION="${IMAGE#sles}"
-SLE_VERSION="${SLE_VERSION%%-docker.$ARCH*$EXT}"
+declare -A SUSE_PRODUCT_MAP
 
-NAME="sles${SLE_VERSION}-docker-image"
+SUSE_PRODUCT_MAP[sles]="SUSE Linux Enterprise Server"
+SUSE_PRODUCT_MAP[openSUSE]="openSUSE"
+
+SUSE_VERSION="${IMAGE#@(sles|openSUSE)}"
+SUSE_VERSION="${SUSE_VERSION%%-docker.$ARCH*$EXT}"
+SUSE_PRODUCT=$(echo ${IMAGE} | perl -p -e 's/^(sles|openSUSE).*/$1/')
+SUSE_PRODUCT_NAME=${SUSE_PRODUCT_MAP[$SUSE_PRODUCT]}
+
+NAME="${SUSE_PRODUCT}${SUSE_VERSION}-docker-image"
 RELEASE=$(date +%Y%m%d)
 
 VERSION="${IMAGE#$PREFIX}"
@@ -66,11 +75,16 @@ echo "version $VERSION"
 echo "release $RELEASE"
 echo "image_name $IMAGE_NAME"
 
+
+# keep __SLE_VERSION__ in there for backwards compatiblity
+# with older spec file templates
 sed -e "s/__NAME__/$NAME/g" \
     -e "s/__VERSION__/$VERSION/g" \
     -e "s/__RELEASE__/$RELEASE/g" \
     -e "s/__SOURCE__/$IMAGE/g" \
-    -e "s/__SLE_VERSION__/$SLE_VERSION/g" \
+    -e "s/__SLE_VERSION__/$SUSE_VERSION/g" \
+    -e "s/__SUSE_VERSION__/$SUSE_VERSION/g" \
+    -e "s/__SUSE_PRODUCT_NAME__/$SUSE_PRODUCT_NAME/g" \
     -e "s/__IMAGE_NAME__/$IMAGE_NAME/g" \
     < $SPEC_IN \
     > $BUILD_DIR/image.spec

--- a/kiwi_post_run
+++ b/kiwi_post_run
@@ -30,7 +30,7 @@ echo "Using $SPEC_IN as spec file template"
 
 EXT=".tar.xz"
 ARCH=$( rpm --eval '%{_arch}')
-PREFIX="@(sles|openSUSE)*-docker.${ARCH}-"
+PREFIX="@(sles|opensuse)*-docker.${ARCH}-"
 SUFFIX="-Build*${EXT}"
 
 shopt -s nullglob
@@ -50,11 +50,11 @@ echo "Attempting to wrap $IMAGE in a containment rpm ..."
 declare -A SUSE_PRODUCT_MAP
 
 SUSE_PRODUCT_MAP[sles]="SUSE Linux Enterprise Server"
-SUSE_PRODUCT_MAP[openSUSE]="openSUSE"
+SUSE_PRODUCT_MAP[opensuse]="openSUSE"
 
-SUSE_VERSION="${IMAGE#@(sles|openSUSE)}"
+SUSE_VERSION="${IMAGE#@(sles|opensuse)}"
 SUSE_VERSION="${SUSE_VERSION%%-docker.$ARCH*$EXT}"
-SUSE_PRODUCT=$(echo ${IMAGE} | perl -p -e 's/^(sles|openSUSE).*/$1/')
+SUSE_PRODUCT=$(echo ${IMAGE} | perl -p -e 's/^(sles|opensuse).*/$1/')
 SUSE_PRODUCT_NAME=${SUSE_PRODUCT_MAP[$SUSE_PRODUCT]}
 
 NAME="${SUSE_PRODUCT}${SUSE_VERSION}-docker-image"


### PR DESCRIPTION
We would like to have also possibility to build openSUSE docker images, that's way we would like to cherry-pick commits `540c1f7499680eb9fbaacab126c1be3a1e625d71` and `ed9fbadf5a3dd59402e762f76196b552903ae4ae` from https://github.com/M0ses/containment-rpm-docker/tree/regex_for_opensuse