### PR TITLE
Add libxml2-tools package to runtime requirements

### DIFF
--- a/containment-rpm-docker.spec
+++ b/containment-rpm-docker.spec
@@ -34,6 +34,7 @@ Requires:       rubygem(changelog_generator)
 Requires:       rubygem-changelog_generator
 %endif
 Requires:       changelog-generator-data
+Requires:       libxml2-tools
 
 %description
 OBS kiwi_post_run hook to wrap a kiwi-produced image in an rpm package.


### PR DESCRIPTION
Script kiwi_post_run uses xmllint command to parse in secure way
KIWI config.xml file. This tool is part of libxml2-tools package.
Has to be added to requires in containment-rpm-docker.spec file.