### PR TITLE
Updated image 'Provides' and 'Recommends'

### DIFF
--- a/containment-rpm-docker.spec
+++ b/containment-rpm-docker.spec
@@ -18,7 +18,7 @@
 # norootforbuild
 
 Name:           containment-rpm-docker
-Version:        1.3.4
+Version:        1.3.5
 Release:        0
 License:        MIT
 Summary:        Wraps OBS/kiwi-built images in rpms
@@ -47,7 +47,7 @@ image.spec.in), and place the rpm in the correct location that it
 becomes an additional build artefact.
 
 %prep
-%setup -q -n %{name}-master
+%setup -q -n %{name}-%{version}
 
 %build
 

--- a/image.spec.in
+++ b/image.spec.in
@@ -10,7 +10,8 @@ License:        SUSE-EULA
 Source0:        __SOURCE0__
 Source1:        __SOURCE1__
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-Recommends:     sle2docker
+Provides:       docker-image(__PKG_NAME__) = __PKG_VERSION__
+Recommends:     docker
 
 %description
 This package contains the official __SUSE_PRODUCT_NAME__ __SUSE_VERSION__

--- a/kiwi_post_run
+++ b/kiwi_post_run
@@ -116,6 +116,8 @@ sed -e "s/__NAME__/$NAME/g" \
     -e "s/__SLE_VERSION__/$SUSE_VERSION/g" \
     -e "s/__SUSE_VERSION__/$SUSE_VERSION/g" \
     -e "s/__SUSE_PRODUCT_NAME__/$SUSE_PRODUCT_NAME/g" \
+    -e "s/__PKG_NAME__/$PKG_NAME/g" \
+    -e "s/__PKG_VERSION__/$PKG_VERSION/g" \
     < $SPEC_IN \
     > $BUILD_DIR/image.spec
 


### PR DESCRIPTION
This commit includes a Provides section in images rpm. The provided
package uses following scheme:

`Provides: docker-image(<image-name>) = <image-version>`

Note that `<image-name>` and `<image-version>` are independent from the
container name and container tag. Those values make reference to
kiwi project name and version.