### PR TITLE
multi packages in one repo

### DIFF
--- a/kiwi_post_run
+++ b/kiwi_post_run
@@ -120,8 +120,8 @@ sed -e "s/__NAME__/$NAME/g" \
     > $BUILD_DIR/image.spec
 
 changelog-generator --new-packages $PACKAGES \
-  --old-packages /usr/share/changelog-generator-data/old.packages.$ARCH \
-  --changelog /usr/share/changelog-generator-data/old.changes.$ARCH > $BUILD_DIR/image.changes
+  --old-packages /usr/share/changelog-generator-data/$PKG_NAME.old.packages.$ARCH \
+  --changelog /usr/share/changelog-generator-data/$PKG_NAME.old.changes.$ARCH > $BUILD_DIR/image.changes
 
 cat $BUILD_DIR/image.changes >> $BUILD_DIR/image.spec
 mv $BUILD_DIR/image.changes $IMAGE_DIR


### PR DESCRIPTION
add the package name as a prefix in the old.packages and old.changelog:

$PKG_NAME.old.packages.$ARCH
$PKG_NAME.old.changelog.$ARCH

this way, if we have more than one docker image in the same obs repo,
this script will only take the old files for the right package.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>