### PR TITLE
Include symlink to the image with a simplified name

### DIFF
--- a/image.spec.in
+++ b/image.spec.in
@@ -23,6 +23,7 @@ image for Docker.
 install -d -m 755 $RPM_BUILD_ROOT%{_datadir}/suse-docker-images/native
 install -p -D -m 644 %{SOURCE0} $RPM_BUILD_ROOT%{_datadir}/suse-docker-images/native/
 install -p -D -m 644 %{SOURCE1} $RPM_BUILD_ROOT%{_datadir}/suse-docker-images/native/
+ln -s ./$(basename %{SOURCE0}) $RPM_BUILD_ROOT%{_datadir}/suse-docker-images/native/__PKG_NAME__
 
 %clean
 rm -rf $RPM_BUILD_ROOT

--- a/kiwi_post_run
+++ b/kiwi_post_run
@@ -109,6 +109,7 @@ EOF
 # Keep __SLE_VERSION__ in there for backwards compatiblity
 # with older spec file templates
 sed -e "s/__NAME__/$NAME/g" \
+    -e "s/__PKG_NAME__/$PKG_NAME/g" \
     -e "s/__VERSION__/$VERSION/g" \
     -e "s/__RELEASE__/$RELEASE/g" \
     -e "s/__SOURCE0__/$IMAGE/g" \


### PR DESCRIPTION
This commit includes in the resulting docker image RPM a symlink
to the image tarball that does not include any version number, arch
and extension. The symlink is named as it is in the `name` attribute
of the `image` tag within the kiwi description file. This way the
base image version can be updated without having to also update
base image reference inside the derived image kiwi description
file.

Related to bsc#1038192