### PR TITLE
review filenames

### DIFF
--- a/kiwi_post_run
+++ b/kiwi_post_run
@@ -122,12 +122,21 @@ sed -e "s/__NAME__/$NAME/g" \
 
 touch $BUILD_DIR/image.changes
 
-if [ -e $PKG_NAME.old.packages.$ARCH ];then
-    if [ -e $PKG_NAME.old.changes.$ARCH ];then
+echo "Generating changelog for $PKG_NAME $ARCH"
+
+CHANGELOG_FILENAME=/usr/share/changelog-generator-data/old.changes.$PKG_NAME.$ARCH
+PACKAGES_FILENAME=/usr/share/changelog-generator-data/old.packages.$PKG_NAME.$ARCH
+
+if [ -e $PACKAGES_FILENAME ];then
+    if [ -e $CHANGELOG_FILENAME ];then
         changelog-generator --new-packages $PACKAGES \
-          --old-packages /usr/share/changelog-generator-data/$PKG_NAME.old.packages.$ARCH \
-          --changelog /usr/share/changelog-generator-data/$PKG_NAME.old.changes.$ARCH > $BUILD_DIR/image.changes
+          --old-packages $PACKAGES_FILENAME \
+          --changelog $CHANGELOG_FILENAME > $BUILD_DIR/image.changes
+    else
+        echo "no $PACKAGES_FILENAME"
     fi
+else
+    echo "no $CHANGELOG_FILENAME"
 fi
 
 cat $BUILD_DIR/image.changes >> $BUILD_DIR/image.spec


### PR DESCRIPTION
use old.[packages|changes].$PKG_NAME.$ARCH instead, because this way all start
with old. This is just cosmetic but it is how we are doing it in the
kubik project.

Also fix the "if" clauses which were checking for the file existance
which were looking in the wrong path