### PR TITLE
Remove tag from the package name

### DIFF
--- a/kiwi_post_run
+++ b/kiwi_post_run
@@ -76,7 +76,7 @@ echo "Attempting to wrap $IMAGE in a containment rpm ..."
 SUSE_VERSION="${CONTAINER_TAG}"
 SUSE_PRODUCT_NAME="${CONTAINER_NAME}"
 
-NAME="${CONTAINER_NAME}-${CONTAINER_TAG}-docker-image"
+NAME="${CONTAINER_NAME}-docker-image"
 VERSION="${PKG_VERSION}"
 RELEASE=$(date +%Y%m%d)
 


### PR DESCRIPTION
Now the image tag can be updated without creating a different
rpm package for each update.

This commit fixes bsc#1046378.