### PR TITLE
Add a tagfile, a mechanism to determine the latest image

### DIFF
--- a/image.spec.in
+++ b/image.spec.in
@@ -9,6 +9,7 @@ Group:          System/Management
 License:        SUSE-EULA
 Source0:        __SOURCE0__
 Source1:        __SOURCE1__
+Source2:        __SOURCE2__
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 %description
@@ -23,6 +24,7 @@ image for Docker.
 install -d -m 755 $RPM_BUILD_ROOT%{_datadir}/suse-docker-images/native
 install -p -D -m 644 %{SOURCE0} $RPM_BUILD_ROOT%{_datadir}/suse-docker-images/native/
 install -p -D -m 644 %{SOURCE1} $RPM_BUILD_ROOT%{_datadir}/suse-docker-images/native/
+install -p -D -m 644 %{SOURCE2} $RPM_BUILD_ROOT%{_datadir}/suse-docker-images/native/
 ln -s ./$(basename %{SOURCE0}) $RPM_BUILD_ROOT%{_datadir}/suse-docker-images/native/__PKG_NAME__
 
 %clean

--- a/kiwi_post_run
+++ b/kiwi_post_run
@@ -65,6 +65,7 @@ shopt -s extglob
 
 IMAGE=$(echo ${PREFIX}*${SUFFIX})
 METADATA=$(echo ${PREFIX}.metadata)
+TAGFILE=$(echo ${PREFIX}.tag)
 PACKAGES=$(echo ${PREFIX}*.packages)
 
 if [ -z "$IMAGE" ]; then
@@ -98,6 +99,7 @@ echo "version $VERSION"
 echo "release $RELEASE"
 echo "source $IMAGE"
 echo "metadata $METADATA"
+echo "tagfile $TAGFILE"
 
 # Generate metada JSON file for container-feeder
 cat << EOF > $METADATA
@@ -110,6 +112,10 @@ cat << EOF > $METADATA
 }
 EOF
 
+# Generate tagfile for automation to determine the latest, most specific, tag for
+# the currently installed RPM
+echo -n "${SUSE_VERSION}" > $TAGFILE
+
 # Keep __SLE_VERSION__ in there for backwards compatiblity
 # with older spec file templates
 sed -e "s/__NAME__/$NAME/g" \
@@ -118,6 +124,7 @@ sed -e "s/__NAME__/$NAME/g" \
     -e "s/__RELEASE__/$RELEASE/g" \
     -e "s/__SOURCE0__/$IMAGE/g" \
     -e "s/__SOURCE1__/$METADATA/g" \
+    -e "s/__SOURCE2__/$TAGFILE/g" \
     -e "s/__SLE_VERSION__/$SUSE_VERSION/g" \
     -e "s/__SUSE_VERSION__/$SUSE_VERSION/g" \
     -e "s/__SUSE_PRODUCT_NAME__/$SUSE_PRODUCT_NAME/g" \
@@ -149,6 +156,11 @@ mv $BUILD_DIR/image.changes $IMAGE_DIR
 # Copy metadata file to source directory
 if [ ! -f $TOPDIR/SOURCES/$METADATA ]; then
   cp $METADATA $TOPDIR/SOURCES
+fi
+
+# Copy tagfile to source directory
+if [ ! -f $TOPDIR/SOURCES/$TAGFILE ]; then
+  cp $TAGFILE $TOPDIR/SOURCES
 fi
 
 # Local builds have the file already in place, that's not true on IBS


### PR DESCRIPTION
Sometimes, using a ":latest" tag is not enough, for example, when you need to
inform Kubernetes that it should perform a rolling upgrade to the new tag.

By adding a file which contains the most specific tag for a given image, we can
have downstream tools use this to determine the tag that matches the currently
installed RPM.

This is the first part of making this work, where we put the initial tag from the wiki kiwi file in place. This will allow us to update downstream tooling to consume this tag, and then begin to make this tag more specific (i.e. including a build number so each build is unique)