### PR TITLE
Use IBS build number to distinguish releases

### DIFF
--- a/image.spec.in
+++ b/image.spec.in
@@ -9,6 +9,7 @@ Group:          System/Management
 License:        SUSE-EULA
 Source0:        __SOURCE0__
 Source1:        __SOURCE1__
+Source2:        __SOURCE2__
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 %description
@@ -23,6 +24,7 @@ image for Docker.
 install -d -m 755 $RPM_BUILD_ROOT%{_datadir}/suse-docker-images/native
 install -p -D -m 644 %{SOURCE0} $RPM_BUILD_ROOT%{_datadir}/suse-docker-images/native/
 install -p -D -m 644 %{SOURCE1} $RPM_BUILD_ROOT%{_datadir}/suse-docker-images/native/
+install -p -D -m 644 %{SOURCE2} $RPM_BUILD_ROOT%{_datadir}/suse-docker-images/native/
 ln -s ./$(basename %{SOURCE0}) $RPM_BUILD_ROOT%{_datadir}/suse-docker-images/native/__PKG_NAME__
 
 %clean

--- a/kiwi_post_run
+++ b/kiwi_post_run
@@ -52,14 +52,6 @@ if [ -n "$KIWI_NG" ]; then
     SUFFIX=".docker${SUFFIX}"
 fi
 
-# Rename all KIWI files and remove -Build* pattern
-# For example base-salt-master.x86_64-1.0.0-Build1.7.docker.tar.xz
-# will be renamed to base-salt-master.x86_64-1.0.0.docker.tar.xz
-for EXT in "${SUFFIX}" "${SUFFIX}.sha256" ".packages" ".verified"; do
-    FNAME=$(echo ${PREFIX}*${EXT} )
-    mv ${FNAME} ${PREFIX}${EXT}
-done
-
 shopt -s nullglob
 shopt -s extglob
 
@@ -83,7 +75,7 @@ SUSE_PRODUCT_NAME="${CONTAINER_NAME}"
 
 NAME="${CONTAINER_NAME}-docker-image"
 VERSION="${PKG_VERSION}"
-RELEASE=$(date +%Y%m%d)
+RELEASE=$(expr match "$PACKAGES" '.*-Build\(.*\).packages')
 
 # Check if VERSION was defined properly and validate it
 # VERSION for RPM package has to be decimal number separete with dots
@@ -106,7 +98,7 @@ cat << EOF > $METADATA
 {
   "image": {
     "name": "$CONTAINER_RAW",
-    "tags": [ "$CONTAINER_TAG", "latest" ],
+    "tags": [ "${VERSION}-${RELEASE}", "${CONTAINER_TAG}-${RELEASE}", "$CONTAINER_TAG", "latest" ],
     "file": "$IMAGE"
   }
 }
@@ -114,7 +106,7 @@ EOF
 
 # Generate tagfile for automation to determine the latest, most specific, tag for
 # the currently installed RPM
-echo -n "${SUSE_VERSION}" > $TAGFILE
+echo -n "${VERSION}-${RELEASE}" > $TAGFILE
 
 # Keep __SLE_VERSION__ in there for backwards compatiblity
 # with older spec file templates

--- a/kiwi_post_run
+++ b/kiwi_post_run
@@ -65,6 +65,7 @@ shopt -s extglob
 
 IMAGE=$(echo ${PREFIX}*${SUFFIX})
 METADATA=$(echo ${PREFIX}.metadata)
+TAGFILE=$(echo ${PREFIX}.tag)
 PACKAGES=$(echo ${PREFIX}*.packages)
 
 if [ -z "$IMAGE" ]; then
@@ -98,6 +99,7 @@ echo "version $VERSION"
 echo "release $RELEASE"
 echo "source $IMAGE"
 echo "metadata $METADATA"
+echo "tagfile $TAGFILE"
 
 # Generate metada JSON file for container-feeder
 cat << EOF > $METADATA
@@ -110,6 +112,10 @@ cat << EOF > $METADATA
 }
 EOF
 
+# Generate tagfile for automation to determine the latest, most specific, tag for
+# the currently installed RPM
+echo -n "${SUSE_VERSION}" > $TAGFILE
+
 # Keep __SLE_VERSION__ in there for backwards compatiblity
 # with older spec file templates
 sed -e "s/__NAME__/$NAME/g" \
@@ -118,6 +124,7 @@ sed -e "s/__NAME__/$NAME/g" \
     -e "s/__RELEASE__/$RELEASE/g" \
     -e "s/__SOURCE0__/$IMAGE/g" \
     -e "s/__SOURCE1__/$METADATA/g" \
+    -e "s/__SOURCE2__/$TAGFILE/g" \
     -e "s/__SLE_VERSION__/$SUSE_VERSION/g" \
     -e "s/__SUSE_VERSION__/$SUSE_VERSION/g" \
     -e "s/__SUSE_PRODUCT_NAME__/$SUSE_PRODUCT_NAME/g" \
@@ -149,6 +156,11 @@ mv $BUILD_DIR/image.changes $IMAGE_DIR
 # Copy metadata file to source directory
 if [ ! -f $TOPDIR/SOURCES/$METADATA ]; then
   cp $METADATA $TOPDIR/SOURCES
+fi
+
+# Copy tagfile to source directory
+if [ ! -f $TOPDIR/SOURCES/$TAGFILE ]; then
+  cp $TAGFILE $TOPDIR/SOURCES
 fi
 
 # Local builds have the file already in place, that's not true on IBS


### PR DESCRIPTION
This solves a number of problems around updating images within
IBS, and delivering those as updates.

Includes a commit from https://github.com/SUSE/containment-rpm-docker/pull/23 as it updates it - https://github.com/SUSE/containment-rpm-docker/pull/23 should land first, and this should be rebased.