### PR TITLE
Use IBS build number to distinguish releases

### DIFF
--- a/kiwi_post_run
+++ b/kiwi_post_run
@@ -52,14 +52,6 @@ if [ -n "$KIWI_NG" ]; then
     SUFFIX=".docker${SUFFIX}"
 fi
 
-# Rename all KIWI files and remove -Build* pattern
-# For example base-salt-master.x86_64-1.0.0-Build1.7.docker.tar.xz
-# will be renamed to base-salt-master.x86_64-1.0.0.docker.tar.xz
-for EXT in "${SUFFIX}" "${SUFFIX}.sha256" ".packages" ".verified"; do
-    FNAME=$(echo ${PREFIX}*${EXT} )
-    mv ${FNAME} ${PREFIX}${EXT}
-done
-
 shopt -s nullglob
 shopt -s extglob
 
@@ -83,7 +75,7 @@ SUSE_PRODUCT_NAME="${CONTAINER_NAME}"
 
 NAME="${CONTAINER_NAME}-docker-image"
 VERSION="${PKG_VERSION}"
-RELEASE=$(date +%Y%m%d)
+RELEASE=$(expr match "$PACKAGES" '.*-Build\(.*\).packages')
 
 # Check if VERSION was defined properly and validate it
 # VERSION for RPM package has to be decimal number separete with dots
@@ -106,7 +98,7 @@ cat << EOF > $METADATA
 {
   "image": {
     "name": "$CONTAINER_RAW",
-    "tags": [ "$CONTAINER_TAG", "latest" ],
+    "tags": [ "$CONTAINER_TAG", "${CONTAINER_TAG}-${RELEASE}", "latest" ],
     "file": "$IMAGE"
   }
 }
@@ -114,7 +106,7 @@ EOF
 
 # Generate tagfile for automation to determine the latest, most specific, tag for
 # the currently installed RPM
-echo -n "${SUSE_VERSION}" > $TAGFILE
+echo -n "${CONTAINER_TAG}-${RELEASE}" > $TAGFILE
 
 # Keep __SLE_VERSION__ in there for backwards compatiblity
 # with older spec file templates


### PR DESCRIPTION
This solves a number of problems around updating images within
IBS, and delivering those as updates.

This is a rebase from
https://github.com/SUSE/containment-rpm-docker/pull/24

Which Kiall started