### PR TITLE
recommend changelog generator data instead of requiring it

### DIFF
--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -54,11 +54,11 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 %if !0%{?is_opensuse}
 %if 0%{?suse_version} >= 1230
-Requires:       rubygem(changelog_generator)
+Recommends:       rubygem(changelog_generator)
 %else
-Requires:       rubygem-changelog_generator
+Recommends:       rubygem-changelog_generator
 %endif
-Requires:       changelog-generator-data
+Recommends:       changelog-generator-data
 %endif
 Requires:       libxml2-tools
 # Conflicts with other packages that provide /usr/lib/build/kiwi_post_run


### PR DESCRIPTION
Using the changelog generator data is not a hard requirement. You can
build rpms containing containers without creating the changelogs.

This way, it will create the changelogs only if the
changelog-generator-data package is available

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>