### PR TITLE
Update to version 2.0.3:

### DIFF
--- a/container_post_run
+++ b/container_post_run
@@ -98,12 +98,29 @@ SUSE_VERSION="$(echo ${CONTAINER_TAG} | sed "s,.*:,,g")"
 SUSE_PRODUCT_NAME=$(echo ${CONTAINER_TAG} | sed "s,/.*,,g;s,/,-,g")
 
 NAME="${CONTAINER_NAME}-image"
-VERSION="${PKG_VERSION}"
-RELEASE="${PKG_RELEASE}"
+VERSION_FULL="${PKG_VERSION}"
+RELEASE_MACRO="${PKG_RELEASE}"
 
-if [ -z "$RELEASE" ]; then
-    echo "Could not parse release number, setting it to zero"
-    RELEASE=0
+if [[ "$VERSION_FULL" == *-* ]]; then
+    # This is a pre-release version
+    # The RPM 'Version' is the part before the hyphen
+    VERSION="${VERSION_FULL%%-*}"
+    # Get the pre-release identifier
+    PRERELEASE_PART="${VERSION_FULL#*-}"
+    # Sanitize the identifier for the RPM 'Release' field.
+    # This replaces any non-alphanumeric characters with a dot.
+    PRERELEASE_CLEAN=$(echo -n "$PRERELEASE_PART" | tr -c '[:alnum:]' '.')
+
+    # Construct the final 'Release' string for the .spec file.
+    RELEASE="0.${PRERELEASE_CLEAN}"
+    CLEANED_MACRO=${RELEASE_MACRO##+(.)}
+    if [ -n "$CLEANED_MACRO" ]; then
+      RELEASE="${RELEASE}.${CLEANED_MACRO}"
+    fi
+else
+    # This is a stable release
+    VERSION="$VERSION_FULL"
+    RELEASE="${RELEASE_MACRO}"
 fi
 
 # For some time our images where named <name>-docker-image,
@@ -114,11 +131,14 @@ OLD_NAME="${CONTAINER_NAME}-docker-image"
 
 # Check if VERSION was defined properly and validate it
 # VERSION for RPM package has to be decimal number separete with dots
-if ! [[ $VERSION =~ ^([0-9]+\.){0,2}(\*|[0-9]+)$ ]]; then
-    echo "Local build detected or wrong version format"
+# Make it possible to use Major.Minor.Patch.Revision notation
+if ! [[ $VERSION =~ ^[0-9]+(\.[0-9]+){0,3}$ ]]; then
     # Just arbitrarily assign the version since we have nothing else
     # to go on.
+    echo "Invalid version format in '$VERSION_FULL', falling back."
     VERSION="1.0.0"
+    # On fallback, use the basic release macro.
+    RELEASE="${RELEASE_MACRO}"
 fi
 
 echo "name $NAME"

--- a/packaging/suse/containment-rpm.spec
+++ b/packaging/suse/containment-rpm.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package containment-rpm
 #
-# Copyright (c) 2023 SUSE LLC
+# Copyright (c) 2025 SUSE LLC and contributors
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -15,14 +15,13 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
-
 Name:           containment-rpm
-Version:        2.0.0
+Version:        2.0.3
 Release:        0
 Summary:        Wraps OBS docker/kiwi-built images in rpms
 License:        MIT
 Group:          System/Management
-URL:            https://github.com/SUSE/containment-rpm-docker
+URL:            https://github.com/SUSE/containment-rpm
 Source:         https://github.com/SUSE/containment-rpm/archive/refs/tags/v%{version}.tar.gz
 BuildRequires:  filesystem
 Requires:       jq
@@ -38,9 +37,11 @@ Requires:       rubygem(changelog_generator)
 Requires:       rubygem-changelog_generator
 %endif
 %endif
+# Conflicts with other packages that provide /usr/lib/build/kiwi_post_run
+Conflicts:      infos-creator-rpm
 
 %description
-OBS container_post_run hook to wrap a kiwi or docker image in an rpm package.
+OBS container_post_run hook to wrap a kiwi-produced image in an rpm package.
 
 This package should be required by the Build Service project's meta
 prjconf, so that the container_post_run hook is present in the container image

--- a/packaging/suse/make_spec.sh
+++ b/packaging/suse/make_spec.sh
@@ -23,9 +23,9 @@ SAFE_BRANCH=${BRANCH//\//-}
 
 cat <<EOF > ${NAME}.spec
 #
-# spec file for package containment-rpm-docker
+# spec file for package containment-rpm
 #
-# Copyright (c) $YEAR SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) $YEAR SUSE LLC and contributors
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -36,31 +36,32 @@ cat <<EOF > ${NAME}.spec
 # license that conforms to the Open Source Definition (Version 1.9)
 # published by the Open Source Initiative.
 
-# Please submit bugfixes or comments via http://bugs.opensuse.org/
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
-# norootforbuild
 
 Name:           $NAME
 Version:        $VERSION
 Release:        0
+Summary:        Wraps OBS docker/kiwi-built images in rpms
 License:        MIT
-Summary:        Wraps OBS/kiwi-built images in rpms
-Url:            https://github.com/SUSE/containment-rpm-docker
 Group:          System/Management
+URL:            https://github.com/SUSE/containment-rpm
 Source:         ${SAFE_BRANCH}.tar.gz
 BuildRequires:  filesystem
-BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-BuildArch:      noarch
-%if !0%{?is_opensuse}
-%if 0%{?suse_version} >= 1230
-Recommends:       rubygem(changelog_generator)
-%else
-Recommends:       rubygem-changelog_generator
-%endif
-Recommends:       changelog-generator-data
-%endif
+Requires:       jq
 Requires:       libxml2-tools
+BuildArch:      noarch
+# disabled for now, not used for public cloud purpose
+%if 0
+Requires:       changelog-generator-data
+Requires:       libxml2-tools
+%if 0%{?suse_version} >= 1230
+Requires:       rubygem(changelog_generator)
+%else
+Requires:       rubygem-changelog_generator
+%endif
+%endif
 # Conflicts with other packages that provide /usr/lib/build/kiwi_post_run
 Conflicts:      infos-creator-rpm
 
@@ -75,19 +76,19 @@ image.spec.in), and place the rpm in the correct location that it
 becomes an additional build artefact.
 
 %prep
-%setup -q -n %{name}-${SAFE_BRANCH}
+%setup -q
 
 %build
 
 %install
-mkdir -p %{buildroot}/usr/lib/build/
-install -m 644 image.spec.in %{buildroot}/usr/lib/build/
-install -m 755 kiwi_post_run %{buildroot}/usr/lib/build/
+mkdir -p %{buildroot}%{_prefix}/lib/build/post_build.d
+install -m 644 image.spec.in %{buildroot}%{_prefix}/lib/build/
+install -m 755 container_post_run %{buildroot}%{_prefix}/lib/build/post_build.d/
 
 %files
-%defattr(-,root,root)
-/usr/lib/build/kiwi_post_run
-/usr/lib/build/image.spec.in
+%dir %{_prefix}/lib/build/post_build.d
+%{_prefix}/lib/build/post_build.d/*_post_run
+%{_prefix}/lib/build/image.spec.in
 
 %changelog
 EOF


### PR DESCRIPTION
- Update spec file template
- Handle pre-releases when generating the RPM name
- Support Major.Minor.Patch.Revision